### PR TITLE
fix layouts/_default/list.hml

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,9 +9,13 @@
                 {{ if not $type }}
                     {{ $type = "post" }}
                 {{ end }}
-                {{ $pag := .Paginate (where .Pages "Type" $type) }}
+                {{ if .IsHome }}
+                    {{ .Scratch.Set "pag" (.Paginate (where .Site.RegularPages "Type" $type)) }}
+                {{ else }}
+                    {{ .Scratch.Set "pag" (.Paginate (where .Pages "Type" $type)) }}
+                {{ end }}
                 <div class="block">
-                    {{ range $pag.Pages }}
+                    {{ range (.Scratch.Get "pag").Pages }}
                     {{ .Render "li" }}
                     {{ end }}
                 </div>


### PR DESCRIPTION
ref. https://github.com/gohugoio/hugo/releases/tag/v0.58.0

> `home.Pages` now behaves like all the other sections, see #6240. If you want to list all the regular pages, use `.Site.RegularPages.`